### PR TITLE
수정-recipes/create/endblock위치

### DIFF
--- a/recipes/templates/recipes/create.html
+++ b/recipes/templates/recipes/create.html
@@ -23,7 +23,7 @@
 
   <input type="submit" value="작성">
 </form>
-{% endblock content %}
+
 {% block script %}
 <script>
   function previewThumbnail(event) {
@@ -57,3 +57,4 @@
   }
 </style>
 {% endblock script %}
+{% endblock content %}


### PR DESCRIPTION
수정-recipes/create/endblock위치 
이미지 미리보기 관련 JS 위치가 {% endblock content %} 안쪽이어야 오류가 뜨지 않아서 {% endblock content %} 위치를 JS 뒤쪽으로 수정했습니다. 