### PR TITLE
수정-레시피 썸네일 크롭

### DIFF
--- a/recipes/templates/recipes/create.html
+++ b/recipes/templates/recipes/create.html
@@ -19,6 +19,7 @@
     }
 
     #image-container img {
+      width: 100%;
       max-width: 100%;
       height: auto;
       vertical-align: middle;
@@ -29,7 +30,7 @@
       border: 2px solid blue;
       pointer-events: auto;
       width: 100%;
-      height: 300px;
+      height: 400px;
       z-index: 1;
     }
 

--- a/recipes/templates/recipes/create.html
+++ b/recipes/templates/recipes/create.html
@@ -73,7 +73,7 @@
       {{ field.label_tag }}
       {{ field }}
       <input type="hidden" name="crop_y" id="crop-y-input">
-      <input type="hidden" name="crop_height" id="crop-height-input">
+      <input type="hidden" name="container_height" id="container-height-input">
 
     {% elif field.name == 'used_products' %}
     <div class="container used-products__container">
@@ -124,6 +124,7 @@
     
     document.getElementById('overlay-top').style.height = overlayTop + 'px'
     document.getElementById('overlay-bottom').style.height = (imageContainer.offsetHeight - overlayTop - overlayHeight) + 'px'
+    document.getElementById('crop-y-input').value = overlayTop
   }
 
   cropOverlay.addEventListener('mousedown', function(event) {
@@ -171,8 +172,7 @@
         cropOverlay.style.top = overlayTopHeight + 'px'
         maxTop = containerHeight - cropOverlay.offsetHeight
         adjustOverlayHeight()
-        document.getElementById('crop-y-input').value = overlayTopHeight
-        document.getElementById('crop-height-input').value = cropOverlay.offsetHeight
+        document.getElementById('container-height-input').value = containerHeight
       }
     }
 

--- a/recipes/views.py
+++ b/recipes/views.py
@@ -38,7 +38,7 @@ def create(request):
             # 이미지 업로드 및 crop
             img = Image.open(image_file)
             real_y = (crop_y * img.height) / container_height
-            real_crop_height = (img.height * 300) / container_height
+            real_crop_height = (img.height * 400) / container_height
             thumbnail_crop = img.crop((0, real_y, img.width, real_y + real_crop_height))
             file_extension = os.path.splitext(image_file.name)[1]
             save_path = f'thumbnail_crop/{os.path.basename(image_file.name)}{file_extension}'

--- a/recipes/views.py
+++ b/recipes/views.py
@@ -33,12 +33,15 @@ def create(request):
              # 이미지 crop 처리
             image_file = request.FILES.get('thumbnail_upload')
             crop_y = int(request.POST.get('crop_y'))
-            crop_height = int(request.POST.get('crop_height'))
+            container_height = int(request.POST.get('container_height'))
+            print(crop_y)
             # 이미지 업로드 및 crop
             img = Image.open(image_file)
-            thumbnail_crop = img.crop((0, crop_y, img.width, crop_y + crop_height))
+            real_y = (crop_y * img.height) / container_height
+            real_crop_height = (img.height * 300) / container_height
+            thumbnail_crop = img.crop((0, real_y, img.width, real_y + real_crop_height))
             file_extension = os.path.splitext(image_file.name)[1]
-            save_path = f'thumbnail_crop/{img.filename}{file_extension}'
+            save_path = f'thumbnail_crop/{os.path.basename(image_file.name)}{file_extension}'
             temp_file = BytesIO()
             thumbnail_crop.save(temp_file, format='JPEG')
             temp_file.seek(0)


### PR DESCRIPTION
썸네일을 자를 때 실제 이미지 파일의 사이즈와 맞지 않는 문제 해결.
작은 사이즈 이미지 업로드 시 꽉차지 않던 문제 해결.